### PR TITLE
Add TestType, TestResult and SampleDatetime attribute to TestRecord. …

### DIFF
--- a/coronaqr.go
+++ b/coronaqr.go
@@ -53,7 +53,6 @@ type Name struct {
 	GivenNameStd  string `cbor:"gnt" json:"gnt"`
 }
 
-
 // see https://github.com/ehn-dcc-development/ehn-dcc-schema/blob/release/1.3.0/valuesets/disease-agent-targeted.json
 type DiseaseTargeted string
 
@@ -109,29 +108,29 @@ func (tr *TestResult) UnmarshalCBOR(data []byte) error {
 // see https://github.com/ehn-dcc-development/ehn-dcc-schema/blob/release/1.3.0/DCC.Types.schema.json
 type VaccineRecord struct {
 	Target        DiseaseTargeted `cbor:"tg" json:"tg"`
-	Vaccine       string  `cbor:"vp" json:"vp"`
-	Product       string  `cbor:"mp" json:"mp"`
-	Manufacturer  string  `cbor:"ma" json:"ma"`
-	Doses         float64 `cbor:"dn" json:"dn"` // int per the spec, but float64 e.g. in IE
-	DoseSeries    float64 `cbor:"sd" json:"sd"` // int per the spec, but float64 e.g. in IE
-	Date          string  `cbor:"dt" json:"dt"`
-	Country       string  `cbor:"co" json:"co"`
-	Issuer        string  `cbor:"is" json:"is"`
-	CertificateID string  `cbor:"ci" json:"ci"`
+	Vaccine       string          `cbor:"vp" json:"vp"`
+	Product       string          `cbor:"mp" json:"mp"`
+	Manufacturer  string          `cbor:"ma" json:"ma"`
+	Doses         float64         `cbor:"dn" json:"dn"` // int per the spec, but float64 e.g. in IE
+	DoseSeries    float64         `cbor:"sd" json:"sd"` // int per the spec, but float64 e.g. in IE
+	Date          string          `cbor:"dt" json:"dt"`
+	Country       string          `cbor:"co" json:"co"`
+	Issuer        string          `cbor:"is" json:"is"`
+	CertificateID string          `cbor:"ci" json:"ci"`
 }
 
 type TestRecord struct {
-	Target DiseaseTargeted `cbor:"tg" json:"tg"`
-	TestType TestType `cbor:"tt" json:"tt"`
+	Target   DiseaseTargeted `cbor:"tg" json:"tg"`
+	TestType TestType        `cbor:"tt" json:"tt"`
 
 	// Name is the NAA Test Name
 	Name string `cbor:"nm" json:"nm"`
 
 	// Manufacturer is the RAT Test name and manufacturer.
-	Manufacturer string `cbor:"ma" json:"ma"`
-	SampleDatetime time.Time `cbor:"sc" json:"sc"`
-	TestResult TestResult `cbor:"tr" json:"tr"`
-	TestingCentre string `cbor:"tc" json:"tc"`
+	Manufacturer   string     `cbor:"ma" json:"ma"`
+	SampleDatetime time.Time  `cbor:"sc" json:"sc"`
+	TestResult     TestResult `cbor:"tr" json:"tr"`
+	TestingCentre  string     `cbor:"tc" json:"tc"`
 	// Country of Test
 	Country       string `cbor:"co" json:"co"`
 	Issuer        string `cbor:"is" json:"is"`

--- a/coronaqr.go
+++ b/coronaqr.go
@@ -53,9 +53,62 @@ type Name struct {
 	GivenNameStd  string `cbor:"gnt" json:"gnt"`
 }
 
+
+// see https://github.com/ehn-dcc-development/ehn-dcc-schema/blob/release/1.3.0/valuesets/disease-agent-targeted.json
+type DiseaseTargeted string
+
+func (tg *DiseaseTargeted) UnmarshalCBOR(data []byte) error {
+	var id string
+	if err := cbor.Unmarshal(data, &id); err != nil {
+		return err
+	}
+	if id == "840539006" {
+		*tg = "COVID-19"
+	} else {
+		*tg = DiseaseTargeted("Unknown test target value: " + id)
+	}
+	return nil
+}
+
+// see https://github.com/ehn-dcc-development/ehn-dcc-schema/blob/release/1.3.0/valuesets/test-type.json
+type TestType string
+
+func (tt *TestType) UnmarshalCBOR(data []byte) error {
+	var id string
+	if err := cbor.Unmarshal(data, &id); err != nil {
+		return err
+	}
+	if id == "LP6464-4" {
+		*tt = "Nucleic acid amplification with probe detection"
+	} else if id == "LP217198-3" {
+		*tt = "Rapid immunoassay"
+	} else {
+		*tt = TestType("Unknown test type value: " + id)
+	}
+	return nil
+}
+
+// see https://github.com/ehn-dcc-development/ehn-dcc-schema/blob/release/1.3.0/valuesets/test-result.json
+type TestResult string
+
+func (tr *TestResult) UnmarshalCBOR(data []byte) error {
+	var id string
+	if err := cbor.Unmarshal(data, &id); err != nil {
+		return err
+	}
+	if id == "260415000" {
+		*tr = "Not detected"
+	} else if id == "260373001" {
+		*tr = "Detected"
+	} else {
+		*tr = TestResult("Unknown test result value: " + id)
+	}
+	return nil
+}
+
 // see https://github.com/ehn-dcc-development/ehn-dcc-schema/blob/release/1.3.0/DCC.Types.schema.json
 type VaccineRecord struct {
-	Target        string  `cbor:"tg" json:"tg"`
+	Target        DiseaseTargeted `cbor:"tg" json:"tg"`
 	Vaccine       string  `cbor:"vp" json:"vp"`
 	Product       string  `cbor:"mp" json:"mp"`
 	Manufacturer  string  `cbor:"ma" json:"ma"`
@@ -68,26 +121,16 @@ type VaccineRecord struct {
 }
 
 type TestRecord struct {
-	Target string `cbor:"tg" json:"tg"`
-	// "tt": {
-	//   "description": "Type of Test",
-	//   "$ref": "https://id.uvci.eu/DCC.ValueSets.schema.json#/$defs/test-type"
-	// },
+	Target DiseaseTargeted `cbor:"tg" json:"tg"`
+	TestType TestType `cbor:"tt" json:"tt"`
 
 	// Name is the NAA Test Name
 	Name string `cbor:"nm" json:"nm"`
 
 	// Manufacturer is the RAT Test name and manufacturer.
 	Manufacturer string `cbor:"ma" json:"ma"`
-	// "sc": {
-	//   "description": "Date/Time of Sample Collection",
-	//   "type": "string",
-	//   "format": "date-time"
-	// },
-	// "tr": {
-	//   "description": "Test Result",
-	//   "$ref": "https://id.uvci.eu/DCC.ValueSets.schema.json#/$defs/test-result"
-	// },
+	SampleDatetime time.Time `cbor:"sc" json:"sc"`
+	TestResult TestResult `cbor:"tr" json:"tr"`
 	TestingCentre string `cbor:"tc" json:"tc"`
 	// Country of Test
 	Country       string `cbor:"co" json:"co"`
@@ -96,7 +139,7 @@ type TestRecord struct {
 }
 
 type RecoveryRecord struct {
-	Target string `cbor:"tg" json:"tg"`
+	Target DiseaseTargeted `cbor:"tg" json:"tg"`
 
 	//     "fr": {
 	//       "description": "ISO 8601 complete date of first positive NAA test result",


### PR DESCRIPTION
…Translate IDs to display names for TestResult, TestType and Target (type of DiseaseTargeted)

### What does this implement?

It completes TestRecord structure by adding attributes `TestType`, `TestResult` and `SampleDatetime`, accordingly to [ehn-dcc-development/ehn-dcc-schema/DCC.Types.schema.json](https://github.com/ehn-dcc-development/ehn-dcc-schema/blob/release/1.3.0/DCC.Types.schema.json).

In addition, attributes `Target`, `TestType` and `TestResult` use custom `string` types implementing `UnmarshalCBOR()` [interface](https://github.com/fxamacker/cbor/blob/07ff84e9e9eeaada95b13ae115260419d955b80b/decode.go#L110). As a result, IDs are translated into display values according to data at [ehn-dcc-development/ehn-dcc-schema/valuesets/](https://github.com/ehn-dcc-development/ehn-dcc-schema/tree/release/1.3.0/valuesets).

### Example

Before:
```sh
# curl -Ls https://raw.githubusercontent.com/eu-digital-green-certificates/dgc-testdata/main/FR/png/test-pcr_ok.png | zbarimg --raw --quiet - | go run cmd/coronadecode/coronadecode.go
Cryptographic signature check skipped (use -verify)

COVID certificate:
Issued:     2021-06-03 09:54:22 +0200 CEST
Expiration: 2021-06-05 09:54:22 +0200 CEST
Contents:   (coronaqr.CovidCert) {
 Version: (string) (len=5) "1.0.0",
 PersonalName: (coronaqr.Name) {
  FamilyName: (string) (len=6) "Dupond",
  FamilyNameStd: (string) (len=6) "DUPOND",
  GivenName: (string) (len=5) "Marie",
  GivenNameStd: (string) (len=5) "MARIE"
 },
 DateOfBirth: (string) (len=10) "1962-07-01",
 VaccineRecords: ([]coronaqr.VaccineRecord) <nil>,
 TestRecords: ([]coronaqr.TestRecord) (len=1 cap=1) {
  (coronaqr.TestRecord) {
   Target: (string) (len=9) "840539006",
   Name: (string) (len=17) "2019-nCoV RT-qPCR",
   Manufacturer: (string) (len=4) "1232",
   TestingCentre: (string) (len=14) "Testing Centre",
   Country: (string) (len=2) "FR",
   Issuer: (string) (len=10) "Laboratory",
   CertificateID: (string) (len=41) "URN:UVCI:V1:FR:P50E914L54CIP5J0K4EHSCXOS:"
  }
 },
 RecoveryRecords: ([]coronaqr.RecoveryRecord) <nil>
}
```

After:
```sh
# curl -Ls https://raw.githubusercontent.com/eu-digital-green-certificates/dgc-testdata/main/FR/png/test-pcr_ok.png | zbarimg --raw --quiet - | go run cmd/coronadecode/coronadecode.go
Cryptographic signature check skipped (use -verify)

COVID certificate:
Issued:     2021-06-03 09:54:22 +0200 CEST
Expiration: 2021-06-05 09:54:22 +0200 CEST
Contents:   (coronaqr.CovidCert) {
 Version: (string) (len=5) "1.0.0",
 PersonalName: (coronaqr.Name) {
  FamilyName: (string) (len=6) "Dupond",
  FamilyNameStd: (string) (len=6) "DUPOND",
  GivenName: (string) (len=5) "Marie",
  GivenNameStd: (string) (len=5) "MARIE"
 },
 DateOfBirth: (string) (len=10) "1962-07-01",
 VaccineRecords: ([]coronaqr.VaccineRecord) <nil>,
 TestRecords: ([]coronaqr.TestRecord) (len=1 cap=1) {
  (coronaqr.TestRecord) {
   Target: (coronaqr.DiseaseTargeted) (len=8) "COVID-19",
   TestType: (coronaqr.TestType) (len=47) "Nucleic acid amplification with probe detection",
   Name: (string) (len=17) "2019-nCoV RT-qPCR",
   Manufacturer: (string) (len=4) "1232",
   SampleDatetime: (time.Time) 2021-05-16 14:34:56 +0000 UTC,
   TestResult: (coronaqr.TestResult) (len=12) "Not detected",
   TestingCentre: (string) (len=14) "Testing Centre",
   Country: (string) (len=2) "FR",
   Issuer: (string) (len=10) "Laboratory",
   CertificateID: (string) (len=41) "URN:UVCI:V1:FR:P50E914L54CIP5J0K4EHSCXOS:"
  }
 },
 RecoveryRecords: ([]coronaqr.RecoveryRecord) <nil>
}
```

### Comments

Tests have been successfully run against [eu-digital-green-certificates/dgc-testdata](https://github.com/eu-digital-green-certificates/dgc-testdata/tree/5cec4e540f21e9886a34f5bc9875b95d50542b3e) (same errors has before this commit).