### PR TITLE
TestRecord: add attributes TestType, TestResult and SampleDatetime

### DIFF
--- a/coronaqr.go
+++ b/coronaqr.go
@@ -73,6 +73,7 @@ type TestRecord struct {
 	//   "description": "Type of Test",
 	//   "$ref": "https://id.uvci.eu/DCC.ValueSets.schema.json#/$defs/test-type"
 	// },
+	TestType string `cbor:"tt" json:"tt"`
 
 	// Name is the NAA Test Name
 	Name string `cbor:"nm" json:"nm"`
@@ -84,10 +85,12 @@ type TestRecord struct {
 	//   "type": "string",
 	//   "format": "date-time"
 	// },
+	SampleDatetime string `cbor:"sc" json:"sc"`
 	// "tr": {
 	//   "description": "Test Result",
 	//   "$ref": "https://id.uvci.eu/DCC.ValueSets.schema.json#/$defs/test-result"
 	// },
+	TestResult    string `cbor:"tr" json:"tr"`
 	TestingCentre string `cbor:"tc" json:"tc"`
 	// Country of Test
 	Country       string `cbor:"co" json:"co"`

--- a/coronaqr.go
+++ b/coronaqr.go
@@ -68,30 +68,17 @@ type VaccineRecord struct {
 }
 
 type TestRecord struct {
-	Target string `cbor:"tg" json:"tg"`
-	// "tt": {
-	//   "description": "Type of Test",
-	//   "$ref": "https://id.uvci.eu/DCC.ValueSets.schema.json#/$defs/test-type"
-	// },
+	Target   string `cbor:"tg" json:"tg"`
 	TestType string `cbor:"tt" json:"tt"`
 
 	// Name is the NAA Test Name
 	Name string `cbor:"nm" json:"nm"`
 
 	// Manufacturer is the RAT Test name and manufacturer.
-	Manufacturer string `cbor:"ma" json:"ma"`
-	// "sc": {
-	//   "description": "Date/Time of Sample Collection",
-	//   "type": "string",
-	//   "format": "date-time"
-	// },
+	Manufacturer   string `cbor:"ma" json:"ma"`
 	SampleDatetime string `cbor:"sc" json:"sc"`
-	// "tr": {
-	//   "description": "Test Result",
-	//   "$ref": "https://id.uvci.eu/DCC.ValueSets.schema.json#/$defs/test-result"
-	// },
-	TestResult    string `cbor:"tr" json:"tr"`
-	TestingCentre string `cbor:"tc" json:"tc"`
+	TestResult     string `cbor:"tr" json:"tr"`
+	TestingCentre  string `cbor:"tc" json:"tc"`
 	// Country of Test
 	Country       string `cbor:"co" json:"co"`
 	Issuer        string `cbor:"is" json:"is"`


### PR DESCRIPTION
### Reference PRs

Subpart of the PR #5 (without the erroneous IDs translation).

### What does this implement?

Complete `TestRecord` structure with attributes `TestType`, `TestResult` and `SampleDatetime`, according to `test_entry` specification from [ehn-dcc-development/ehn-dcc-schema/DCC.Types.schema.json](https://github.com/ehn-dcc-development/ehn-dcc-schema/blob/release/1.3.0/DCC.Types.schema.json).

### Test

`gofmt` and `go test` : PASS