### PR TITLE
Include Issuer in output

### DIFF
--- a/cmd/coronadecode/coronadecode.go
+++ b/cmd/coronadecode/coronadecode.go
@@ -17,6 +17,7 @@ import (
 func printCertificate(decoded *coronaqr.Decoded) {
 	fmt.Printf("\n")
 	fmt.Printf("COVID certificate:\n")
+	fmt.Printf("Issuer:     %v\n", decoded.Issuer)
 	fmt.Printf("Issued:     %v\n", decoded.IssuedAt)
 	fmt.Printf("Expiration: %v\n", decoded.Expiration)
 	fmt.Printf("Contents:   ")

--- a/coronaqr.go
+++ b/coronaqr.go
@@ -26,6 +26,7 @@ import (
 // possibly verified.
 type Decoded struct {
 	Cert       CovidCert
+	Issuer     string
 	IssuedAt   time.Time
 	Expiration time.Time
 
@@ -275,6 +276,7 @@ func (u *unverifiedCOSE) decoded() *Decoded {
 	return &Decoded{
 		Cert:       cert,
 		SignedBy:   u.cert,
+		Issuer:     u.claims.Iss,
 		IssuedAt:   time.Unix(u.claims.Iat, 0),
 		Expiration: time.Unix(u.claims.Exp, 0),
 	}


### PR DESCRIPTION
Every cert I've tested so far includes claims -260, 1, 4 and 6 and hence I think 1 should be included in the regular output