### PR TITLE
Option to print the parsed cert even when encountering verification issues

### DIFF
--- a/cmd/coronadecode/coronadecode.go
+++ b/cmd/coronadecode/coronadecode.go
@@ -26,6 +26,7 @@ func printCertificate(decoded *coronaqr.Decoded) {
 func main() {
 	var (
 		verify    = flag.Bool("verify", false, "verify the signature in addition to decoding")
+		insecure  = flag.Bool("insecure", false, "don't abort program when encountering issues on verification (e.g. expired)")
 		trustlist = flag.String("trustlist",
 			"trustlistmirror/de",
 			"Trustlist to obtain certificates from. One of trustlistmirror/de, trustlistmirror/at or trustlistmirror/fr")
@@ -68,7 +69,11 @@ func main() {
 	log.Printf("trustlist %q initialized: %v", *trustlist, certProv)
 	decoded, err := unverified.Verify(certProv)
 	if err != nil {
-		log.Fatalf("verification failed: %v", err)
+		if *insecure {
+			log.Printf("verification failed: %v", err)
+		} else {
+			log.Fatalf("verification failed: %v", err)
+		}
 	}
 	if cert := decoded.SignedBy; cert == nil {
 		fmt.Printf("Cryptographic signature successfully verified\n")

--- a/coronaqr.go
+++ b/coronaqr.go
@@ -346,7 +346,7 @@ func (u *Unverified) Verify(certprov PublicKeyProvider) (*Decoded, error) {
 		}
 	}
 	if err := u.u.verify(expired, certprov); err != nil {
-		return nil, err
+		return u.u.decoded(), err
 	}
 
 	return u.u.decoded(), nil

--- a/coronaqr.go
+++ b/coronaqr.go
@@ -334,8 +334,8 @@ func (u *Unverified) SkipVerification() *Decoded {
 	return u.u.decoded()
 }
 
-// Verify checks the cryptographic signature and returns the verified EU Digital
-// COVID Certificate (EUDCC) or an error if verification fails.
+// Verify checks the cryptographic signature and returns the decoded EU Digital
+// COVID Certificate (EUDCC) and additionally an error if verification fails.
 //
 // certprov can optionally implement the CertificateProvider interface.
 func (u *Unverified) Verify(certprov PublicKeyProvider) (*Decoded, error) {


### PR DESCRIPTION
When wanting to inspect a certificate that is perfectly valid but unfortunately expired, I'm not given any output.
This PR makes it possible to view the cert regardless (without changing the source code every time 🙈)