### PR TITLE
feat: add Key ID (KID)

### DIFF
--- a/coronaqr.go
+++ b/coronaqr.go
@@ -34,6 +34,7 @@ type Decoded struct {
 	// has been successfully verified, if Verify() was used and the trustlist
 	// makes available certificates (as opposed to just public keys).
 	SignedBy *x509.Certificate
+	Kid      []byte
 }
 
 // see https://github.com/ehn-dcc-development/ehn-dcc-schema
@@ -277,6 +278,7 @@ func (u *unverifiedCOSE) decoded() *Decoded {
 		Cert:       cert,
 		SignedBy:   u.cert,
 		Issuer:     u.claims.Iss,
+		Kid:        u.p.Kid,
 		IssuedAt:   time.Unix(u.claims.Iat, 0),
 		Expiration: time.Unix(u.claims.Exp, 0),
 	}

--- a/coronaqr_test.go
+++ b/coronaqr_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -109,6 +110,10 @@ func testInteropDecode(t *testing.T, tt rawTestdata) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if decoded.Kid == nil {
+		t.Fatalf("kid cannot be nil")
 	}
 
 	if diff := cmp.Diff(tt.JSON, decoded.Cert); diff != "" {
@@ -308,7 +313,7 @@ func TestInterop(t *testing.T) {
 		}
 		for _, match := range matches {
 			t.Run(match, func(t *testing.T) {
-				b, err := ioutil.ReadFile(match)
+				b, err := os.ReadFile(match)
 				if err != nil {
 					t.Fatalf("ReadFile(%s): %v", match, err)
 				}


### PR DESCRIPTION
- fix: remove failure if CertificateProvider cannot be cast
- fix: get rid of deprecated ioutil.ReadFile

---

Reworked from #13 
